### PR TITLE
Add sum to hidden imports from prelude

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -10,7 +10,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Lazy as T.L
 import GHC.Generics
 import qualified Network.Wai.Metrics as Monitoring.HTTP
-import Prelude hiding (filter, lookup, not, null, tail)
+import Prelude hiding (filter, lookup, not, null, sum, tail)
 import qualified System.Remote.Monitoring as Monitoring
 import Web.Scotty
 


### PR DESCRIPTION
When running through the workshop I got an ambiguous instance when writing the `sum` fn, hiding the `sum` from prelude fixed this.